### PR TITLE
Add nginx-mod-http-headers-more and more_clear_headers 'Server'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.17
 
 RUN apk add --no-cache\
     'nginx~=1.22' \
+    'nginx-mod-http-headers-more==1.22.1-r0' \
     'py3-pip~=22.3.1' &&\
     pip3 install --no-cache-dir \
     j2cli==0.3.10 \

--- a/README.md
+++ b/README.md
@@ -49,5 +49,6 @@ The above will get the password from AWS Secret Manager secret named `staging`, 
 - `HEALTHCHECK_LISTEN=127.0.0.1` IP address the healthcheck listens on. Defaults to 127.0.0.1.
 - `NOSNIFF=true` enables X-Content-Type-Options: nosniff. Defaults to `false`.
 - `CSP=true` enables Content Security Policy. Defaults to `false`.
+- `CLEAR_SERVER_HEADER` removes the `Server` header from responses. Defaults to `true`.
 
 ...and some others. See the code.

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,3 +1,5 @@
+load_module modules/ngx_http_headers_more_filter_module.so;
+
 user  nginx;
 worker_processes {{ env("WORKER_PROCESSES", "1") }};
 
@@ -20,6 +22,8 @@ http {
 
   sendfile        on;
   server_tokens   off;
+  more_clear_headers 'Server';
+  
   {%- if REAL_IP == 'true' or REAL_IP_CIDRS %}
   real_ip_header {{ env('REAL_IP_HEADER', 'X-Forwarded-For') }};
   proxy_ignore_client_abort on;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,4 +1,6 @@
+{% if env("CLEAR_SERVER_HEADER", "true") == 'true' %}
 load_module modules/ngx_http_headers_more_filter_module.so;
+{% endif %}
 
 user  nginx;
 worker_processes {{ env("WORKER_PROCESSES", "1") }};
@@ -22,7 +24,10 @@ http {
 
   sendfile        on;
   server_tokens   off;
+
+  {% if env("CLEAR_SERVER_HEADER", "true") == 'true' %}
   more_clear_headers 'Server';
+  {% endif %}
   
   {%- if REAL_IP == 'true' or REAL_IP_CIDRS %}
   real_ip_header {{ env('REAL_IP_HEADER', 'X-Forwarded-For') }};


### PR DESCRIPTION
Checked on a live nginx with a Django server behind.

`curl` result without the added code:
```
HTTP/2 200
date: Tue, 18 Apr 2023 18:45:17 GMT
...
server: nginx
...
```

`curl` result with the added code:
```
HTTP/2 200
date: Tue, 18 Apr 2023 18:46:31 GMT
...
```

With the `server_tokens off;`, the `server` was still visible in the response.

Without the Django behind, `server` is not there so I guess Django added it somewhere.